### PR TITLE
Remove Ajax block on displaymode=page

### DIFF
--- a/view/frontend/layout/catalog_category_view_displaymode_page.xml
+++ b/view/frontend/layout/catalog_category_view_displaymode_page.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column-full-width" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="web200.navigation.ajax" remove="true" />
+    </body>
+</page>


### PR DESCRIPTION
In a project of ours we got an issue where we used certain categorypages for just content ("displaymode = page"). The page broke because the `web200.navigation.ajax` block expects products to be present.

It's very weird that Magento does this, since you've included this block only on `view_type_layered`, but apparently a `displaymode_page` category is still seen as `type_layered`.