### PR TITLE
Fix missing navigation menu on category pages with display mode cms block only

### DIFF
--- a/view/frontend/layout/catalog_category_view_displaymode_page.xml
+++ b/view/frontend/layout/catalog_category_view_displaymode_page.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column-full-width" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="web200.navigation.ajax" remove="true" />
     </body>


### PR DESCRIPTION
This fixes #12 

There is no reason for this layout change.

As far as I know, there isn't even a layout "1column-full-width" in vanilla Magento.