### PR TITLE
Update elasticsuite-ajax.js

### DIFF
--- a/view/frontend/web/js/elasticsuite-ajax.js
+++ b/view/frontend/web/js/elasticsuite-ajax.js
@@ -109,7 +109,7 @@ define([
                 e.preventDefault();
             });
 
-            $(document).on('click', self.options.limitControl, function (e) {
+            $(document).on('change', self.options.limitControl, function (e) {
                 self.updateLayer(window.location.href, 'product_list_limit', e.currentTarget.options[e.currentTarget.selectedIndex].value);
                 e.preventDefault();
             });


### PR DESCRIPTION
Fixes AJAX loading on limit control when value is changed. Actually it's broken - limit control is HTML select element, so if event is "click" its just reloading the page after clicking on control.